### PR TITLE
feat: due date generation (10th + >=30 days)

### DIFF
--- a/src/domain/dateUtils.ts
+++ b/src/domain/dateUtils.ts
@@ -1,0 +1,54 @@
+export type IsoDate = `${number}-${number}-${number}`
+
+/** Parse an ISO yyyy-mm-dd date as a UTC midnight Date. */
+export function parseIsoDate(date: IsoDate): Date {
+  // Using Date.UTC avoids timezone DST surprises.
+  const [y, m, d] = date.split('-').map((x) => Number(x))
+  return new Date(Date.UTC(y, m - 1, d))
+}
+
+/** Format a Date (assumed UTC midnight or at least stable) to ISO yyyy-mm-dd in UTC. */
+export function formatIsoDate(date: Date): IsoDate {
+  const y = date.getUTCFullYear()
+  const m = String(date.getUTCMonth() + 1).padStart(2, '0')
+  const d = String(date.getUTCDate()).padStart(2, '0')
+  return `${y}-${m}-${d}` as IsoDate
+}
+
+export function daysBetweenUtc(a: Date, b: Date): number {
+  const msPerDay = 24 * 60 * 60 * 1000
+  return Math.floor((b.getTime() - a.getTime()) / msPerDay)
+}
+
+export function isWeekendUtc(date: Date): boolean {
+  const dow = date.getUTCDay() // 0=Sun, 6=Sat
+  return dow === 0 || dow === 6
+}
+
+export function addMonthsUtc(date: Date, months: number): Date {
+  // Keep day-of-month when possible; if it overflows (e.g., 31st), JS rolls.
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() + months, date.getUTCDate()))
+}
+
+export function setDayOfMonthUtc(date: Date, dayOfMonth: number): Date {
+  return new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), dayOfMonth))
+}
+
+export type IsHolidayUtc = (date: Date) => boolean
+
+/**
+ * Working-day shifting.
+ *
+ * ADR TBD: for now, shift forward to the next working day.
+ * (This matches most consumer expectations and is deterministic.)
+ */
+export function shiftForwardToWorkingDayUtc(
+  date: Date,
+  isHoliday: IsHolidayUtc = () => false,
+): Date {
+  let d = new Date(date)
+  while (isWeekendUtc(d) || isHoliday(d)) {
+    d = new Date(d.getTime() + 24 * 60 * 60 * 1000)
+  }
+  return d
+}

--- a/src/domain/dueDates.ts
+++ b/src/domain/dueDates.ts
@@ -1,0 +1,67 @@
+import {
+  addMonthsUtc,
+  daysBetweenUtc,
+  formatIsoDate,
+  parseIsoDate,
+  setDayOfMonthUtc,
+  shiftForwardToWorkingDayUtc,
+  type IsHolidayUtc,
+  type IsoDate,
+} from './dateUtils'
+
+export type GenerateDueDatesOptions = {
+  /** Installments are due on this day-of-month (default: 10). */
+  dueDayOfMonth?: number
+  /** First installment must be >= this many days after start date (default: 30). */
+  minDaysFromStartToFirstDue?: number
+  /** Optional holiday predicate (UTC). */
+  isHolidayUtc?: IsHolidayUtc
+  /** If true, shift weekend/holiday forward to next working day (default: true). */
+  shiftToWorkingDay?: boolean
+}
+
+/**
+ * Generate installment due dates.
+ *
+ * Rules (MVP):
+ * - Base due date = dueDayOfMonth for each month.
+ * - First due date must be at least minDaysFromStartToFirstDue after startDate.
+ *   If the current month's due date violates it, use next month.
+ * - If due date falls on weekend/holiday, shift forward to the next working day.
+ */
+export function generateDueDates(
+  startDate: IsoDate,
+  numberOfInstallments: number,
+  options: GenerateDueDatesOptions = {},
+): IsoDate[] {
+  const dueDayOfMonth = options.dueDayOfMonth ?? 10
+  const minDays = options.minDaysFromStartToFirstDue ?? 30
+  const isHolidayUtc = options.isHolidayUtc ?? (() => false)
+  const shouldShift = options.shiftToWorkingDay ?? true
+
+  const start = parseIsoDate(startDate)
+
+  // Candidate 1: dueDay in the start month.
+  let monthCursor = setDayOfMonthUtc(start, dueDayOfMonth)
+
+  // If that candidate is before start date, move to next month.
+  if (daysBetweenUtc(start, monthCursor) < 0) {
+    monthCursor = setDayOfMonthUtc(addMonthsUtc(start, 1), dueDayOfMonth)
+  }
+
+  // Enforce first installment >= minDays.
+  if (daysBetweenUtc(start, monthCursor) < minDays) {
+    monthCursor = setDayOfMonthUtc(addMonthsUtc(monthCursor, 1), dueDayOfMonth)
+  }
+
+  const out: IsoDate[] = []
+  for (let i = 0; i < numberOfInstallments; i += 1) {
+    let due = setDayOfMonthUtc(addMonthsUtc(monthCursor, i), dueDayOfMonth)
+    if (shouldShift) {
+      due = shiftForwardToWorkingDayUtc(due, isHolidayUtc)
+    }
+    out.push(formatIsoDate(due))
+  }
+
+  return out
+}

--- a/src/domain/index.ts
+++ b/src/domain/index.ts
@@ -1,1 +1,3 @@
 export * from './loanInput'
+export * from './dateUtils'
+export * from './dueDates'


### PR DESCRIPTION
Closes #9

Implements due date generation:
- Due day-of-month = 10th (configurable)
- First due date is at least 30 days after start date
- Weekend/holiday shifting (MVP): shift forward to next working day (holiday predicate injectable)

No holiday calendar yet (handled in #10).