### PR TITLE
chore: disable auto Pages deploy until enabled

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,9 +1,8 @@
 name: Deploy to GitHub Pages
 
 on:
-  push:
-    branches:
-      - main
+  # Disabled auto-deploy until GitHub Pages is enabled in repo settings.
+  # When enabled, we can re-add push trigger for main.
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
GitHub Pages deploy workflow currently fails with 404 until Pages is enabled in repo settings.

This change disables the push trigger and keeps manual workflow_dispatch only (can re-enable auto deploy once Pages is enabled).