### PR TITLE
chore: enable Pages deploy on push to main

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -1,8 +1,9 @@
 name: Deploy to GitHub Pages
 
 on:
-  # Disabled auto-deploy until GitHub Pages is enabled in repo settings.
-  # When enabled, we can re-add push trigger for main.
+  push:
+    branches:
+      - main
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Re-enables automatic GitHub Pages deployment on every push to main.