### PR TITLE
fix: correct legal cap formula (2 × (ref rate + 3.5pp))

### DIFF
--- a/docs/ADR/0002-nbp-reference-rate-source.md
+++ b/docs/ADR/0002-nbp-reference-rate-source.md
@@ -6,7 +6,7 @@ Proposed
 
 ## Context
 
-Interest rate validation requires max interest = NBP reference rate + 3.5pp.
+Interest rate validation requires max interest = 2 × (NBP reference rate + 3.5pp).
 
 We need the current NBP reference rate.
 

--- a/masterdoc.md
+++ b/masterdoc.md
@@ -27,7 +27,7 @@ User-provided inputs:
 
 Nominal interest rate **cannot exceed** the maximum regulated by the Polish Civil Code:
 
-- **Max interest = NBP reference rate + 3.5 percentage points**
+- **Max interest = 2 × (NBP reference rate + 3.5 percentage points)**
 
 #### NBP reference rate source (MVP proposal)
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -44,7 +44,7 @@ function App() {
 
   const maxNominalPct = useMemo(() => {
     if (refRatePct == null) return null
-    return refRatePct + 3.5
+    return 2 * (refRatePct + 3.5)
   }, [refRatePct])
 
   const derived = useMemo(() => {


### PR DESCRIPTION
Fixes max nominal interest legal cap formula per Marcin correction: max = 2 × (NBP reference rate + 3.5pp). Updates UI calculation + documentation.