### PR TITLE
Fix mobile horizontal scroll (table-only scroll)

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -41,6 +41,11 @@ h2 {
   align-items: start;
 }
 
+/* Allow grid children to shrink so the table doesn't force page-level horizontal scroll */
+.grid > * {
+  min-width: 0;
+}
+
 @media (max-width: 900px) {
   .grid {
     grid-template-columns: 1fr;
@@ -86,7 +91,10 @@ input {
 }
 
 .tableWrap {
-  overflow: auto;
+  max-width: 100%;
+  overflow-x: auto;
+  overflow-y: hidden;
+  -webkit-overflow-scrolling: touch;
   border: 1px solid var(--border);
   border-radius: 8px;
 }

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,12 @@ body {
   color: var(--text);
 }
 
+/* Avoid accidental page-level horizontal scroll on small screens */
+html,
+body {
+  overflow-x: hidden;
+}
+
 a {
   font-weight: 600;
   color: var(--accent);


### PR DESCRIPTION
Fixes mobile layout where the whole page could become horizontally scrollable. Ensures grid children can shrink and confines horizontal scrolling to the schedule table wrapper.\n\nCloses #42